### PR TITLE
Allow JRuby failures in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,4 +41,5 @@ matrix:
   allow_failures:
     - rvm: "ruby-head"
     - rvm: "jruby-head"
+    - rvm: "jruby"
     - gemfile: gemfiles/rails-head.gemfile


### PR DESCRIPTION
JRuby builds are fragile on Travis for some external reasons.  Hence, these failures should not break the whole build.