### PR TITLE
Rename validation helper method

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -36,6 +36,13 @@ Add the following to your model:
 validates :my_url_attribute, uri_format: true
 ----
 
+Also, an old-fashioned validation helper is provided:
+
+[source,ruby]
+----
+validates_url_format_of :my_url_attribute
+----
+
 == Error messages
 
 You can set the error message as an additional parameter

--- a/lib/uri_format_validator.rb
+++ b/lib/uri_format_validator.rb
@@ -1,6 +1,7 @@
 require "uri_format_validator/version"
 require "uri_format_validator/localization"
 require "validators/uri_format_validator"
+require "validators/helper_methods"
 
 # This is a placeholder...
 module UriFormatValidator

--- a/lib/validators/helper_methods.rb
+++ b/lib/validators/helper_methods.rb
@@ -1,0 +1,16 @@
+require "active_model"
+
+module ActiveModel
+  module Validations
+    module HelperMethods
+      # Encapsulates the pattern of wanting to validate an URL.
+      #
+      #   class Post < ActiveRecord::Base
+      #     validates_url_of :permalink
+      #   end
+      def validates_url_of(*attr_names)
+        validates_with UriFormatValidator, _merge_attributes(attr_names)
+      end
+    end
+  end
+end

--- a/lib/validators/helper_methods.rb
+++ b/lib/validators/helper_methods.rb
@@ -6,9 +6,9 @@ module ActiveModel
       # Encapsulates the pattern of wanting to validate an URL.
       #
       #   class Post < ActiveRecord::Base
-      #     validates_url_of :permalink
+      #     validates_uri_format_of :permalink
       #   end
-      def validates_url_of(*attr_names)
+      def validates_uri_format_of(*attr_names)
         validates_with UriFormatValidator, _merge_attributes(attr_names)
       end
     end

--- a/lib/validators/uri_format_validator.rb
+++ b/lib/validators/uri_format_validator.rb
@@ -191,16 +191,5 @@ module ActiveModel
         nil
       end
     end
-
-    module HelperMethods
-      # Encapsulates the pattern of wanting to validate an URL.
-      #
-      #   class Post < ActiveRecord::Base
-      #     validates_url_of :permalink
-      #   end
-      def validates_url_of(*attr_names)
-        validates_with UriFormatValidator, _merge_attributes(attr_names)
-      end
-    end
   end
 end

--- a/spec/helper_methods_spec.rb
+++ b/spec/helper_methods_spec.rb
@@ -1,0 +1,14 @@
+require "spec_helper"
+
+describe ActiveModel::Validations::HelperMethods do
+  let(:post) { Post.new }
+
+  it "provides alternative, old-fashioned way to set validations" do
+    Post.validates_url_of :url
+
+    post.url = "http://google"
+    expect(post).not_to be_valid
+    post.url = "http://google.com"
+    expect(post).to be_valid
+  end
+end

--- a/spec/helper_methods_spec.rb
+++ b/spec/helper_methods_spec.rb
@@ -4,7 +4,7 @@ describe ActiveModel::Validations::HelperMethods do
   let(:post) { Post.new }
 
   it "provides alternative, old-fashioned way to set validations" do
-    Post.validates_url_of :url
+    Post.validates_uri_format_of :url
 
     post.url = "http://google"
     expect(post).not_to be_valid

--- a/spec/url_validator_spec.rb
+++ b/spec/url_validator_spec.rb
@@ -279,13 +279,4 @@ RSpec.describe UriFormatValidator do
       end
     end
   end
-
-  it "provides alternative, old-fashioned way to set validations" do
-    Post.validates_url_of :url
-
-    post.url = "http://google"
-    expect(post).not_to be_valid
-    post.url = "http://google.com"
-    expect(post).to be_valid
-  end
 end


### PR DESCRIPTION
Since the validator class has been renamed, the helper method should be renamed accordingly.