### PR TITLE
Improve code style

### DIFF
--- a/lib/uri_format_validator/validators/uri_format_validator.rb
+++ b/lib/uri_format_validator/validators/uri_format_validator.rb
@@ -75,8 +75,10 @@ module UriFormatValidator
             when :resorvable then validate_resorvable(url.to_s)
             when :reachable then validate_reachable(url)
             when :retrievable then validate_retrievable(url)
-            else raise ArgumentError.new("Invalid option for 'resolvability', valid options are: \
-                                          :resorvable, :reachable, :retrievable")
+            else
+              msg = "Invalid option for 'resolvability', valid options are: \
+                    :resorvable, :reachable, :retrievable"
+              raise ArgumentError.new(msg)
             end
           end
         end
@@ -193,8 +195,9 @@ module UriFormatValidator
         if RESOLVABILITY_SUPPORTED_SCHEMES.include?(sch)
           true
         else
-          raise ArgumentExcpeption.new("The scheme #{sch} not supported for resolvability validation. \
-                                        Supported schemes: #{REACHABILITY_SUPPORTED_SCHEMES}")
+          msg = "The scheme #{sch} not supported for resolvability validation. \
+                Supported schemes: #{REACHABILITY_SUPPORTED_SCHEMES}"
+          raise ArgumentExcpeption.new(msg)
         end
       end
 

--- a/lib/uri_format_validator/validators/uri_format_validator.rb
+++ b/lib/uri_format_validator/validators/uri_format_validator.rb
@@ -84,7 +84,8 @@ module UriFormatValidator
         end
 
         %i[path query fragment].each do |prop|
-          send(:"validate_#{prop}", options[prop], url.send(prop)) if options.key?(prop)
+          next unless options.key?(prop)
+          send(:"validate_#{prop}", options[prop], url.send(prop))
         end
       end
 

--- a/lib/uri_format_validator/validators/uri_format_validator.rb
+++ b/lib/uri_format_validator/validators/uri_format_validator.rb
@@ -201,7 +201,7 @@ module UriFormatValidator
 
       def use_https?(url)
         url.scheme == "https" ||
-          (url.scheme == nil && @schemes.is_a?(Array) && @schemes.include?("https"))
+          (url.scheme.nil? && @schemes.try(:include?, "https"))
       end
 
       def generic_validate_retrievable(url)

--- a/lib/uri_format_validator/validators/uri_format_validator.rb
+++ b/lib/uri_format_validator/validators/uri_format_validator.rb
@@ -129,8 +129,10 @@ module UriFormatValidator
       def validate_authority(option, url)
         fail_if option.is_a?(Regexp) && url.host !~ option
         fail_if option.is_a?(Array) && !option.include?(url.host)
-        check_reserved_domains(url) if option.is_a?(Hash) &&
-                                       option[:allow_reserved] == false
+
+        if option.is_a?(Hash) && option[:allow_reserved] == false
+          check_reserved_domains(url)
+        end
       end
 
       def accept_relative_urls?

--- a/lib/uri_format_validator/validators/uri_format_validator.rb
+++ b/lib/uri_format_validator/validators/uri_format_validator.rb
@@ -161,7 +161,7 @@ module UriFormatValidator
       # TODO:
       # host exists and resolves to an ip address
       def validate_resorvable(url)
-        Resolv.getaddress(url) != nil
+        !Resolv.getaddress(url).nil?
       rescue Resolv::ResolvError, Resolv::ResolvTimeout
         false
       rescue

--- a/lib/uri_format_validator/validators/uri_format_validator.rb
+++ b/lib/uri_format_validator/validators/uri_format_validator.rb
@@ -162,9 +162,7 @@ module UriFormatValidator
       # host exists and resolves to an ip address
       def validate_resorvable(url)
         Resolv.getaddress(url) != nil
-      rescue Resolv::ResolvError
-        false
-      rescue Resolv::ResolvTimeout
+      rescue Resolv::ResolvError, Resolv::ResolvTimeout
         false
       rescue
         nil


### PR DESCRIPTION
Fix most of Rubocop warnings.

After these changes, only 7 style guide violations remain. Neither is trivial to fix, hence they'll be successively removed along other refactoring.

Continuation of #42 (closed).