### PR TITLE
Rename local variables and translation string

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -59,7 +59,7 @@ or you can use locales:
 en:
   errors:
     messages:
-      invalid_url: 'is not a valid URL'
+      invalid_uri: 'is not a valid URL'
 ----
 
 == Development

--- a/lib/uri_format_validator/locale/en.yml
+++ b/lib/uri_format_validator/locale/en.yml
@@ -1,4 +1,4 @@
 en:
   errors:
     messages:
-      invalid_url: 'is not a valid URL'
+      invalid_uri: 'is not a valid URL'

--- a/lib/uri_format_validator/validators/uri_format_validator.rb
+++ b/lib/uri_format_validator/validators/uri_format_validator.rb
@@ -38,7 +38,7 @@ module UriFormatValidator
           else options[:scheme]
           end
 
-        options[:message] ||= I18n.t("errors.messages.invalid_url")
+        options[:message] ||= I18n.t("errors.messages.invalid_uri")
         super(options)
       end
 


### PR DESCRIPTION
Prefer word "uri" over "url" in naming as this validator is for URIs which are more general than URLs. Although some features make sense only for URLs, all the local variables get renamed for simplicity and consistency.