### PR TITLE
Refactor and simplify validation flow

### DIFF
--- a/lib/uri_format_validator/validators/uri_format_validator.rb
+++ b/lib/uri_format_validator/validators/uri_format_validator.rb
@@ -65,13 +65,13 @@ module UriFormatValidator
         else
           validate_domain(uri_string)
           validate_authority(options[:authority], uri) if options.key?(:authority)
-          validate_scheme(options[:scheme], uri.scheme) if options.key?(:scheme)
+          validate_scheme(options[:scheme], uri) if options.key?(:scheme)
           validate_resolvability(options[:resolvability], uri) if options.key?(:resolvability)
         end
 
         %i[path query fragment].each do |prop|
           next unless options.key?(prop)
-          send(:"validate_#{prop}", options[prop], uri.send(prop))
+          send(:"validate_#{prop}", options[prop], uri)
         end
       end
 
@@ -100,7 +100,8 @@ module UriFormatValidator
         fail_unless uri =~ regexp
       end
 
-      def validate_scheme(_option, scheme)
+      def validate_scheme(_option, uri)
+        scheme = uri.scheme
         if @schemes.is_a?(Regexp)
           fail_if scheme !~ @schemes
         else
@@ -108,18 +109,19 @@ module UriFormatValidator
         end
       end
 
-      def validate_path(option, path)
+      def validate_path(option, uri)
+        path = uri.path
         fail_if option == true  && path == "/" || path == ""
         fail_if option == false && path != "/" && path != ""
         fail_if option.is_a?(Regexp) && path !~ option
       end
 
-      def validate_query(option, query)
-        fail_unless query.present? == option
+      def validate_query(option, uri)
+        fail_unless uri.query.present? == option
       end
 
-      def validate_fragment(option, fragment)
-        fail_unless fragment.present? == option
+      def validate_fragment(option, uri)
+        fail_unless uri.fragment.present? == option
       end
 
       def validate_authority(option, uri)

--- a/lib/uri_format_validator/validators/uri_format_validator.rb
+++ b/lib/uri_format_validator/validators/uri_format_validator.rb
@@ -58,7 +58,7 @@ module UriFormatValidator
 
       def do_checks(uri_string)
         begin
-          uri = URI(uri_string.to_s)
+          uri = URI(uri_string)
         rescue URI::InvalidURIError
           fail_if true
         end

--- a/lib/uri_format_validator/validators/uri_format_validator.rb
+++ b/lib/uri_format_validator/validators/uri_format_validator.rb
@@ -69,18 +69,7 @@ module UriFormatValidator
           validate_domain(uri_string)
           validate_authority(options[:authority], uri) if options.key?(:authority)
           validate_scheme(options[:scheme], uri.scheme) if options.key?(:scheme)
-
-          if options.key?(:resolvability)
-            case options[:resolvability]
-            when :resorvable then validate_resorvable(uri.to_s)
-            when :reachable then validate_reachable(uri)
-            when :retrievable then validate_retrievable(uri)
-            else
-              msg = "Invalid option for 'resolvability', valid options are: \
-                    :resorvable, :reachable, :retrievable"
-              raise ArgumentError.new(msg)
-            end
-          end
+          validate_resolvability(options[:resolvability], uri) if options.key?(:resolvability)
         end
 
         %i[path query fragment].each do |prop|
@@ -133,6 +122,18 @@ module UriFormatValidator
 
         if option.is_a?(Hash) && option[:allow_reserved] == false
           check_reserved_domains(uri)
+        end
+      end
+
+      def validate_resolvability(option, uri)
+        case option
+        when :resorvable then validate_resorvable(uri.to_s)
+        when :reachable then validate_reachable(uri)
+        when :retrievable then validate_retrievable(uri)
+        else
+          msg = "Invalid option for 'resolvability', valid options are: \
+                :resorvable, :reachable, :retrievable"
+          raise ArgumentError.new(msg)
         end
       end
 

--- a/lib/uri_format_validator/validators/uri_format_validator.rb
+++ b/lib/uri_format_validator/validators/uri_format_validator.rb
@@ -64,15 +64,10 @@ module UriFormatValidator
           validate_domain_absense(uri)
         else
           validate_domain(uri_string)
-          validate_authority(options[:authority], uri) if options.key?(:authority)
-          validate_scheme(options[:scheme], uri) if options.key?(:scheme)
-          validate_resolvability(options[:resolvability], uri) if options.key?(:resolvability)
+          validate_against_options(uri, :authority, :scheme, :resolvability)
         end
 
-        %i[path query fragment].each do |prop|
-          next unless options.key?(prop)
-          send(:"validate_#{prop}", options[prop], uri)
-        end
+        validate_against_options(uri, :path, :query, :fragment)
       end
 
       # Warning!  The +URI+ method behaviour is inconsistent across VMs.
@@ -98,6 +93,13 @@ module UriFormatValidator
 
       def validate_domain(uri)
         fail_unless uri =~ regexp
+      end
+
+      def validate_against_options(uri, *option_keys_list)
+        option_keys_list.each do |option_name|
+          next unless options.key?(option_name)
+          send(:"validate_#{option_name}", options[option_name], uri)
+        end
       end
 
       def validate_scheme(_option, uri)

--- a/lib/uri_format_validator/validators/uri_format_validator.rb
+++ b/lib/uri_format_validator/validators/uri_format_validator.rb
@@ -57,11 +57,8 @@ module UriFormatValidator
       RESOLVABILITY_SUPPORTED_SCHEMES = %w[http https].freeze
 
       def do_checks(uri_string)
-        begin
-          uri = URI(uri_string)
-        rescue URI::InvalidURIError
-          fail_if true
-        end
+        uri = string_to_uri(uri_string)
+        fail_unless uri
 
         if accept_relative_uris?
           validate_domain_absense(uri)
@@ -76,6 +73,15 @@ module UriFormatValidator
           next unless options.key?(prop)
           send(:"validate_#{prop}", options[prop], uri.send(prop))
         end
+      end
+
+      # Warning!  The +URI+ method behaviour is inconsistent across VMs.
+      # For instance, Rubinius allows leading and trailing spaces.  Non-nil
+      # return value doesn't guarantee that URI is indeed well-formed.
+      def string_to_uri(uri_string)
+        URI(uri_string)
+      rescue URI::InvalidURIError
+        nil
       end
 
       def set_failure_message(record, attribute)


### PR DESCRIPTION
Refactor large and complex `do_checks` method.

Extract larger pieces of logic into separate methods. Improve argument lists in methods in order to make them similar to each other, then remove duplications.

After merging this one in, only 2 code style violations are left in the project.