### PR TITLE
Rename validator

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -1,5 +1,7 @@
 == Not released yet
 
+* Rename validator from `uri_format` to `uri`.
+
 == 0.1.0
 
 * Improve error message in English, add Polish translation

--- a/README.adoc
+++ b/README.adoc
@@ -31,7 +31,7 @@ in your models, like that:
 [source,ruby]
 ----
 class User < ActiveRecord::Base
-  validates :home_site_url, uri_format: true
+  validates :home_site_url, uri: true
 end
 ----
 
@@ -53,28 +53,28 @@ and fragment.
 
 [source,ruby]
 ----
-validates :home_site_url, uri_format: { scheme: /https?/ }
-validates :home_site_url, uri_format: { scheme: %w[ssh telnet] }
+validates :home_site_url, uri: { scheme: /https?/ }
+validates :home_site_url, uri: { scheme: %w[ssh telnet] }
 
-validates :home_site_url, uri_format: { authority: /\.example\./ }
-validates :home_site_url, uri_format: { authority: %w[example.com example.test] }
+validates :home_site_url, uri: { authority: /\.example\./ }
+validates :home_site_url, uri: { authority: %w[example.com example.test] }
 
 # require path component (`/` is not enough)
-validates :home_site_url, uri_format: { path: true }
+validates :home_site_url, uri: { path: true }
 # disallow presence of path component
-validates :home_site_url, uri_format: { path: false }
+validates :home_site_url, uri: { path: false }
 # match path against regular expression
-validates :home_site_url, uri_format: { path: /regexp/ }
+validates :home_site_url, uri: { path: /regexp/ }
 
 # require query component
-validates :home_site_url, uri_format: { query: true }
+validates :home_site_url, uri: { query: true }
 # disallow presence of query component
-validates :home_site_url, uri_format: { query: false }
+validates :home_site_url, uri: { query: false }
 
 # require fragment component
-validates :home_site_url, uri_format: { fragment: true }
+validates :home_site_url, uri: { fragment: true }
 # disallow presence of fragment component
-validates :home_site_url, uri_format: { fragment: false }
+validates :home_site_url, uri: { fragment: false }
 ----
 
 When `scheme` option is unspecified, only http and https are allowed.
@@ -86,7 +86,7 @@ to allow relative and disallow absolute URLs:
 
 [source,ruby]
 ----
-validates :home_site_url, uri_format: { authority: false }
+validates :home_site_url, uri: { authority: false }
 ----
 
 === Reachable URLs
@@ -97,7 +97,7 @@ with 2xx status code.  Otherwise, given value is considered invalid.
 
 [source,ruby]
 ----
-validates :home_site_url, uri_format: { retrievable: true }
+validates :home_site_url, uri: { retrievable: true }
 ----
 
 === Error messages
@@ -106,7 +106,7 @@ You can also override the default error message:
 
 [source,ruby]
 ----
-validates :my_url_attribute, uri_format: true, message: 'is not a valid URL'
+validates :my_url_attribute, uri: true, message: 'is not a valid URL'
 ----
 
 Alternatively, you can provide your own localization string for

--- a/lib/uri_format_validator/validators.rb
+++ b/lib/uri_format_validator/validators.rb
@@ -1,7 +1,7 @@
 # (c) Copyright 2017 Ribose Inc.
 #
 
-require "uri_format_validator/validators/uri_format_validator"
+require "uri_format_validator/validators/uri_validator"
 require "uri_format_validator/validators/helper_methods"
 
 module UriFormatValidator

--- a/lib/uri_format_validator/validators/helper_methods.rb
+++ b/lib/uri_format_validator/validators/helper_methods.rb
@@ -12,7 +12,7 @@ module UriFormatValidator
       #     validates_uri_format_of :permalink
       #   end
       def validates_uri_format_of(*attr_names)
-        validates_with UriFormatValidator, _merge_attributes(attr_names)
+        validates_with UriValidator, _merge_attributes(attr_names)
       end
     end
   end

--- a/lib/uri_format_validator/validators/uri_validator.rb
+++ b/lib/uri_format_validator/validators/uri_validator.rb
@@ -12,7 +12,7 @@ module UriFormatValidator
     #
     # TODO: documentation
     #
-    class UriFormatValidator < ::ActiveModel::EachValidator
+    class UriValidator < ::ActiveModel::EachValidator
       SCHEMES = %w[
         aaa aaas about acap acct cap cid coap coaps crid data dav dict dns
         example file ftp geo go gopher h323 http https iax icap im imap info ipp

--- a/spec/uri_format_validator_spec.rb
+++ b/spec/uri_format_validator_spec.rb
@@ -3,7 +3,7 @@
 
 require "spec_helper"
 
-RSpec.describe UriFormatValidator::Validators::UriFormatValidator do
+RSpec.describe UriFormatValidator::Validators::UriValidator do
   let(:post) { Post.new }
 
   context "when url field is empty" do

--- a/spec/uri_format_validator_spec.rb
+++ b/spec/uri_format_validator_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe UriFormatValidator::Validators::UriValidator do
 
   context "when url field is empty" do
     it "fails with default message" do
-      Post.validates :url, uri_format: true
+      Post.validates :url, uri: true
 
       post.url = ""
       expect(post).to_not be_valid
@@ -16,7 +16,7 @@ RSpec.describe UriFormatValidator::Validators::UriValidator do
     end
 
     it "fails for nil values" do
-      Post.validates :url, uri_format: true
+      Post.validates :url, uri: true
 
       post.url = nil
       expect(post).to_not be_valid
@@ -24,13 +24,13 @@ RSpec.describe UriFormatValidator::Validators::UriValidator do
     end
 
     it "pass if accept nil values" do
-      Post.validates :url, uri_format: true, allow_nil: true
+      Post.validates :url, uri: true, allow_nil: true
       post.url = nil
       expect(post).to be_valid
     end
 
     it "pass if accept blank values" do
-      Post.validates :url, uri_format: true, allow_blank: true
+      Post.validates :url, uri: true, allow_blank: true
       post.url = ""
       expect(post).to be_valid
     end
@@ -38,7 +38,7 @@ RSpec.describe UriFormatValidator::Validators::UriValidator do
 
   context "when url is present" do
     before do
-      Post.validates :url, uri_format: true
+      Post.validates :url, uri: true
     end
 
     valid_urls = [
@@ -71,7 +71,7 @@ RSpec.describe UriFormatValidator::Validators::UriValidator do
     end
 
     it "reject malformed strings" do
-      Post.validates :url, uri_format: true
+      Post.validates :url, uri: true
       post.url = " http://google.com "
       expect(post).to_not be_valid
     end
@@ -81,13 +81,13 @@ RSpec.describe UriFormatValidator::Validators::UriValidator do
     context "when value is :all" do
       it "check for scheme match" do
         post.url = "telnet://www.example.com/"
-        Post.validates :url, uri_format: { scheme: :all }
+        Post.validates :url, uri: { scheme: :all }
         expect(post).to be_valid
       end
 
       it "reject wrong scheme" do
         post.url = "undefined://example.com/"
-        Post.validates :url, uri_format: { scheme: :all }
+        Post.validates :url, uri: { scheme: :all }
         expect(post).to_not be_valid
       end
     end
@@ -95,13 +95,13 @@ RSpec.describe UriFormatValidator::Validators::UriValidator do
     context "when value is a regexp" do
       it "check for scheme match" do
         post.url = "http://www.example.com/"
-        Post.validates :url, uri_format: { scheme: /http|https/ }
+        Post.validates :url, uri: { scheme: /http|https/ }
         expect(post).to be_valid
       end
 
       it "reject missing scheme" do
         post.url = "ftp://example.com/"
-        Post.validates :url, uri_format: { scheme: /http|https/ }
+        Post.validates :url, uri: { scheme: /http|https/ }
         expect(post).to_not be_valid
       end
     end
@@ -109,13 +109,13 @@ RSpec.describe UriFormatValidator::Validators::UriValidator do
     context "when value is an array" do
       it "check for scheme match" do
         post.url = "ftp://example.com/"
-        Post.validates :url, uri_format: { scheme: %w[http ftp] }
+        Post.validates :url, uri: { scheme: %w[http ftp] }
         expect(post).to be_valid
       end
 
       it "reject missing scheme" do
         post.url = "telnet://google.com/"
-        Post.validates :url, uri_format: { scheme: %w[http ftp] }
+        Post.validates :url, uri: { scheme: %w[http ftp] }
         expect(post).to_not be_valid
       end
     end
@@ -125,13 +125,13 @@ RSpec.describe UriFormatValidator::Validators::UriValidator do
     context "when value is true" do
       it "check for path presence" do
         post.url = "http://example.com/some/path"
-        Post.validates :url, uri_format: { path: true }
+        Post.validates :url, uri: { path: true }
         expect(post).to be_valid
       end
 
       it "reject missing path" do
         post.url = "http://example.com/"
-        Post.validates :url, uri_format: { path: true }
+        Post.validates :url, uri: { path: true }
         expect(post).to_not be_valid
       end
     end
@@ -139,13 +139,13 @@ RSpec.describe UriFormatValidator::Validators::UriValidator do
     context "when value is false" do
       it "check for path absence" do
         post.url = "http://example.com/some/path"
-        Post.validates :url, uri_format: { path: false }
+        Post.validates :url, uri: { path: false }
         expect(post).to_not be_valid
       end
 
       it "reject path presence" do
         post.url = "http://example.com/"
-        Post.validates :url, uri_format: { path: false }
+        Post.validates :url, uri: { path: false }
         expect(post).to be_valid
       end
     end
@@ -153,13 +153,13 @@ RSpec.describe UriFormatValidator::Validators::UriValidator do
     context "when value is a regexp" do
       it "check for path match" do
         post.url = "http://example.com/some/path"
-        Post.validates :url, uri_format: { path: /path/ }
+        Post.validates :url, uri: { path: /path/ }
         expect(post).to be_valid
       end
 
       it "reject missing path" do
         post.url = "http://example.com/"
-        Post.validates :url, uri_format: { path: /notfound/ }
+        Post.validates :url, uri: { path: /notfound/ }
         expect(post).to_not be_valid
       end
     end
@@ -169,13 +169,13 @@ RSpec.describe UriFormatValidator::Validators::UriValidator do
     context "when value is true" do
       it "check for query presence" do
         post.url = "http://example.com/?q=query"
-        Post.validates :url, uri_format: { query: true }
+        Post.validates :url, uri: { query: true }
         expect(post).to be_valid
       end
 
       it "reject missing query" do
         post.url = "http://example.com/"
-        Post.validates :url, uri_format: { query: true }
+        Post.validates :url, uri: { query: true }
         expect(post).to_not be_valid
       end
     end
@@ -183,13 +183,13 @@ RSpec.describe UriFormatValidator::Validators::UriValidator do
     context "when value is false" do
       it "check for query absence" do
         post.url = "http://example.com/?q=query"
-        Post.validates :url, uri_format: { query: false }
+        Post.validates :url, uri: { query: false }
         expect(post).to_not be_valid
       end
 
       it "reject query presence" do
         post.url = "http://example.com/"
-        Post.validates :url, uri_format: { query: false }
+        Post.validates :url, uri: { query: false }
         expect(post).to be_valid
       end
     end
@@ -199,13 +199,13 @@ RSpec.describe UriFormatValidator::Validators::UriValidator do
     context "when value is true" do
       it "check for fragment presence" do
         post.url = "http://example.com/#fragment"
-        Post.validates :url, uri_format: { fragment: true }
+        Post.validates :url, uri: { fragment: true }
         expect(post).to be_valid
       end
 
       it "reject missing fragment" do
         post.url = "http://example.com/"
-        Post.validates :url, uri_format: { fragment: true }
+        Post.validates :url, uri: { fragment: true }
         expect(post).to_not be_valid
       end
     end
@@ -213,13 +213,13 @@ RSpec.describe UriFormatValidator::Validators::UriValidator do
     context "when value is false" do
       it "check for fragment absence" do
         post.url = "http://example.com/#fragment"
-        Post.validates :url, uri_format: { fragment: false }
+        Post.validates :url, uri: { fragment: false }
         expect(post).to_not be_valid
       end
 
       it "reject fragment presence" do
         post.url = "http://example.com/"
-        Post.validates :url, uri_format: { fragment: false }
+        Post.validates :url, uri: { fragment: false }
         expect(post).to be_valid
       end
     end
@@ -229,13 +229,13 @@ RSpec.describe UriFormatValidator::Validators::UriValidator do
     context "when value is false" do
       it "check for authority absence" do
         post.url = "/relative/path?query=true"
-        Post.validates :url, uri_format: { authority: false }
+        Post.validates :url, uri: { authority: false }
         expect(post).to be_valid
       end
 
       it "reject authority presence" do
         post.url = "http://example.com/relative/path"
-        Post.validates :url, uri_format: { authority: false }
+        Post.validates :url, uri: { authority: false }
         expect(post).to_not be_valid
       end
     end
@@ -243,13 +243,13 @@ RSpec.describe UriFormatValidator::Validators::UriValidator do
     context "when value is a regexp" do
       it "check for authority match" do
         post.url = "http://example.com"
-        Post.validates :url, uri_format: { authority: /example.com/ }
+        Post.validates :url, uri: { authority: /example.com/ }
         expect(post).to be_valid
       end
 
       it "reject missing authority" do
         post.url = "http://example.com"
-        Post.validates :url, uri_format: { authority: /google.com/ }
+        Post.validates :url, uri: { authority: /google.com/ }
         expect(post).to_not be_valid
       end
     end
@@ -259,14 +259,14 @@ RSpec.describe UriFormatValidator::Validators::UriValidator do
         post.url = "http://example.com"
         Post.validates(
           :url,
-          uri_format: { authority: %w[example.com google.com] },
+          uri: { authority: %w[example.com google.com] },
         )
         expect(post).to be_valid
       end
 
       it "reject missing authority" do
         post.url = "http://example.com"
-        Post.validates :url, uri_format: { authority: %w[google.com] }
+        Post.validates :url, uri: { authority: %w[google.com] }
         expect(post).to_not be_valid
       end
     end
@@ -276,7 +276,7 @@ RSpec.describe UriFormatValidator::Validators::UriValidator do
         post.url = "http://example.com"
         Post.validates(
           :url,
-          uri_format: { authority: { allow_reserved: false } },
+          uri: { authority: { allow_reserved: false } },
         )
         expect(post).to_not be_valid
       end
@@ -288,21 +288,21 @@ RSpec.describe UriFormatValidator::Validators::UriValidator do
       it "allows URI with http scheme which points to retrievable content" do
         post.url = "http://example.com/relative/path"
         stub_request(:head, post.url).to_return(status: 200)
-        Post.validates :url, uri_format: { retrievable: false, scheme: :all }
+        Post.validates :url, uri: { retrievable: false, scheme: :all }
         expect(post).to be_valid
       end
 
       it "allows URI with https scheme which points to retrievable content" do
         post.url = "https://example.com/relative/path"
         stub_request(:head, post.url).to_return(status: 200)
-        Post.validates :url, uri_format: { retrievable: false, scheme: :all }
+        Post.validates :url, uri: { retrievable: false, scheme: :all }
         expect(post).to be_valid
       end
 
       it "allows URI which points to unretrievable content" do
         post.url = "http://example.com/relative/path"
         stub_request(:head, post.url).to_return(status: 404)
-        Post.validates :url, uri_format: { retrievable: false, scheme: :all }
+        Post.validates :url, uri: { retrievable: false, scheme: :all }
         expect(post).to be_valid
       end
 
@@ -310,7 +310,7 @@ RSpec.describe UriFormatValidator::Validators::UriValidator do
         pending "The list of allowed schemes is broken, see issue #62"
         post.url = "ssh://git@github.com:riboseinc/uri_format_validator.git"
         stub_request(:head, post.url).to_return(status: 200)
-        Post.validates :url, uri_format: { retrievable: false, scheme: :all }
+        Post.validates :url, uri: { retrievable: false, scheme: :all }
         expect(post).to be_valid
       end
     end
@@ -319,21 +319,21 @@ RSpec.describe UriFormatValidator::Validators::UriValidator do
       it "allows URI with http scheme which points to retrievable content" do
         post.url = "http://example.com/relative/path"
         stub_request(:head, post.url).to_return(status: 200)
-        Post.validates :url, uri_format: { retrievable: true, scheme: :all }
+        Post.validates :url, uri: { retrievable: true, scheme: :all }
         expect(post).to be_valid
       end
 
       it "allows URI with https scheme which points to retrievable content" do
         post.url = "https://example.com/relative/path"
         stub_request(:head, post.url).to_return(status: 200)
-        Post.validates :url, uri_format: { retrievable: true, scheme: :all }
+        Post.validates :url, uri: { retrievable: true, scheme: :all }
         expect(post).to be_valid
       end
 
       fit "disallows URI which points to unretrievable content" do
         post.url = "http://example.com/relative/path"
         stub_request(:head, post.url).to_return(status: 404)
-        Post.validates :url, uri_format: { retrievable: true, scheme: :all }
+        Post.validates :url, uri: { retrievable: true, scheme: :all }
         expect(post).to be_invalid
       end
 
@@ -341,7 +341,7 @@ RSpec.describe UriFormatValidator::Validators::UriValidator do
           despite :scheme option value" do
         post.url = "ssh://git@github.com:riboseinc/uri_format_validator.git"
         stub_request(:head, post.url).to_return(status: 200)
-        Post.validates :url, uri_format: { retrievable: true, scheme: :all }
+        Post.validates :url, uri: { retrievable: true, scheme: :all }
         expect(post).to be_invalid
       end
     end


### PR DESCRIPTION
Rename validator from `UriFormatValidator` to simply `UriValidator`. Fixes #46. Fixes #76.