### PR TITLE
Switch to Addressable

### DIFF
--- a/lib/uri_format_validator/validators/uri_validator.rb
+++ b/lib/uri_format_validator/validators/uri_validator.rb
@@ -2,7 +2,7 @@
 #
 
 require "active_model"
-require "uri"
+require "addressable"
 require "active_support/core_ext"
 require "net/http"
 require "resolv"
@@ -68,12 +68,9 @@ module UriFormatValidator
         validate_against_options(uri, :path, :query, :fragment)
       end
 
-      # Warning!  The +URI+ method behaviour is inconsistent across VMs.
-      # For instance, Rubinius allows leading and trailing spaces.  Non-nil
-      # return value doesn't guarantee that URI is indeed well-formed.
       def string_to_uri(uri_string)
-        URI(uri_string)
-      rescue URI::InvalidURIError
+        Addressable::URI.parse(uri_string)
+      rescue Addressable::URI::InvalidURIError
         nil
       end
 

--- a/uri_format_validator.gemspec
+++ b/uri_format_validator.gemspec
@@ -25,6 +25,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = ">= 2.2.2"
 
   spec.add_runtime_dependency "activemodel", ">= 4.0.0", "< 6"
+  spec.add_runtime_dependency "addressable", "~> 2.5"
 
   spec.add_development_dependency "bundler", "~> 1.14"
   spec.add_development_dependency "pry"


### PR DESCRIPTION
Use [Addressable](https://github.com/sporkmonger/addressable) gem. It is more feature-complete and behaves consistently in various VMs, contrary to stdlib's URI.