### PR TITLE
Drop support for Rubinius

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,6 @@ rvm:
   - "2.3"
   - "2.2.2"
   - "ruby-head"
-  - "rbx-3"
   - "jruby"
   - "jruby-head"
 


### PR DESCRIPTION
Rubinius appears to be very difficult in testing.  Builds take over five minutes.  Cucumber tests tend to fail randomly, or produce weird output.