### PR TITLE
Fix Rubocop issues

### DIFF
--- a/.hound.yml
+++ b/.hound.yml
@@ -1,4 +1,4 @@
 ruby:
-  Enabled: true
+  enabled: true
   config_file: .rubocop.yml
   rubocop_version: 0.50.0

--- a/.hound.yml
+++ b/.hound.yml
@@ -1,3 +1,4 @@
 ruby:
   Enabled: true
   config_file: .rubocop.yml
+  rubocop_version: 0.50.0

--- a/uri_format_validator.gemspec
+++ b/uri_format_validator.gemspec
@@ -33,7 +33,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "pry"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"
-  spec.add_development_dependency "rubocop", "~> 0.49.1"
+  spec.add_development_dependency "rubocop", "~> 0.50.0"
   spec.add_development_dependency "simplecov"
   spec.add_development_dependency "webmock", "~> 3.0"
 end


### PR DESCRIPTION
* Fix Rubocop version constraint in gemspec (match what is in `.rubocop.yml` and CodeClimate configs)
* Specify Rubocop version in Hound configuration