### PR TITLE
Remove non-existing option from specs

### DIFF
--- a/spec/uri_validator_spec.rb
+++ b/spec/uri_validator_spec.rb
@@ -69,7 +69,7 @@ RSpec.describe UriFormatValidator::Validators::UriValidator do
     end
 
     context "when unspecified" do
-      let(:validation_options) { { scheme: :all } }
+      let(:validation_options) { {} }
 
       it "allows URI with http scheme which points to retrievable content" do
         allow_uri(retrievable_http_url)
@@ -90,7 +90,7 @@ RSpec.describe UriFormatValidator::Validators::UriValidator do
     end
 
     context "when is false" do
-      let(:validation_options) { { retrievable: false, scheme: :all } }
+      let(:validation_options) { { retrievable: false } }
 
       it "allows URI with http scheme which points to retrievable content" do
         allow_uri(retrievable_http_url)
@@ -111,7 +111,7 @@ RSpec.describe UriFormatValidator::Validators::UriValidator do
     end
 
     context "when is true" do
-      let(:validation_options) { { retrievable: true, scheme: :all } }
+      let(:validation_options) { { retrievable: true } }
 
       it "allows URI with http scheme which points to retrievable content" do
         allow_uri(retrievable_http_url)


### PR DESCRIPTION
The `:scheme` option has been temporarily removed in 6839f41adee0b4422c (pull request #83).  Providing it in these tests was the odd requirement of the previous implementation.  Now it may be (and should be) removed from these examples as irrelevant.