### PR TITLE
Bump to v0.2.1 to match 0d28a6c1c906

### DIFF
--- a/lib/uri_format_validator/version.rb
+++ b/lib/uri_format_validator/version.rb
@@ -2,5 +2,5 @@
 #
 
 module UriFormatValidator
-  VERSION = "0.2.0".freeze
+  VERSION = "0.2.1".freeze
 end


### PR DESCRIPTION
The v0.2.0 release has been erroneous, therefore it has been immediately succeeded with v0.2.1.  This commit updates the version number to reflect that on master branch as well.