### PR TITLE
Setting option to false always disables it

### DIFF
--- a/lib/uri_format_validator/validators/uri_validator.rb
+++ b/lib/uri_format_validator/validators/uri_validator.rb
@@ -52,7 +52,7 @@ module UriFormatValidator
 
       def validate_against_options(uri, *option_keys_list)
         option_keys_list.each do |option_name|
-          next unless options.key?(option_name)
+          next unless options[option_name]
           send(:"validate_#{option_name}", options[option_name], uri)
         end
       end

--- a/spec/uri_validator_spec.rb
+++ b/spec/uri_validator_spec.rb
@@ -72,6 +72,16 @@ RSpec.describe UriFormatValidator::Validators::UriValidator do
       end
     end
 
+    context "when is false" do
+      let(:validation_options) { { scheme: false } }
+
+      it "allows URIs with any scheme" do
+        allow_uri(http_uri)
+        allow_uri(https_uri)
+        allow_uri(file_uri)
+      end
+    end
+
     context "when is a string" do
       let(:validation_options) { { scheme: "https" } }
 


### PR DESCRIPTION
In the previous implementation, `false` was sometimes a meaningful setting.  I think it was bit confusing, it's better to add few more symbol-based suboptions than that.