### PR TITLE
Introduce :host validation option

### DIFF
--- a/features/uri_component_constraints/host.feature
+++ b/features/uri_component_constraints/host.feature
@@ -1,0 +1,200 @@
+Feature: Host component constraints
+  Scenario: By default, accept every valid URI
+    Given a file named "test_example_model.rb" with:
+      """ruby
+      require "active_model"
+      require "uri_format_validator"
+
+      class ExampleModel
+        include ActiveModel::Validations
+
+        attr_accessor :uri
+        validates :uri, uri: true
+      end
+
+      object = ExampleModel.new
+
+      object.uri = "http://example.com"
+      puts object.valid?
+
+      # IPv4 localhost
+      object.uri = "https://127.0.0.1/example/path"
+      puts object.valid?
+
+      # IPv6 localhost
+      object.uri = "https://[::1]/example/path"
+      puts object.valid?
+
+      # Hierarchical URI with authority component empty
+      object.uri = "file:///dev/null"
+      puts object.valid?
+
+      # Non-hierarchical URI
+      object.uri = "urn:ISSN:0167-6423"
+      puts object.valid?
+      """
+
+    When I run `ruby test_example_model.rb`
+
+    Then it should pass with exactly:
+      """
+      true
+      true
+      true
+      true
+      true
+      """
+
+  Scenario: When host option is a string, it specifies the only allowed host
+    Given a file named "test_example_model.rb" with:
+      """ruby
+      require "active_model"
+      require "uri_format_validator"
+
+      class ExampleModel
+        include ActiveModel::Validations
+
+        attr_accessor :uri
+        validates :uri, uri: { host: "example.com" }
+      end
+
+      object = ExampleModel.new
+
+      object.uri = "http://example.com"
+      puts object.valid?
+
+      object.uri = "ssh://admin:admin1@example.com:22/protected"
+      puts object.valid?
+
+      object.uri = "http://subdomain.example.com"
+      puts object.valid?
+
+      # IP-based URI
+      object.uri = "https://127.0.0.1/example/path"
+      puts object.valid?
+
+      # Hierarchical URI with authority component empty
+      object.uri = "file:///dev/null"
+      puts object.valid?
+
+      # Non-hierarchical URI
+      object.uri = "urn:ISSN:0167-6423"
+      puts object.valid?
+      """
+
+    When I run `ruby test_example_model.rb`
+
+    Then it should pass with exactly:
+      """
+      true
+      true
+      false
+      false
+      false
+      false
+      """
+
+  Scenario: When host option is an array, it specifies a set of allowed hosts
+    Given a file named "test_example_model.rb" with:
+      """ruby
+      require "active_model"
+      require "uri_format_validator"
+
+      class ExampleModel
+        include ActiveModel::Validations
+
+        attr_accessor :uri
+        validates :uri, uri: { host: %w[example.com 127.0.0.1] }
+      end
+
+      object = ExampleModel.new
+
+      object.uri = "http://example.com"
+      puts object.valid?
+
+      object.uri = "http://subdomain.example.com"
+      puts object.valid?
+
+      # IP-based URI
+      object.uri = "https://127.0.0.1/example/path"
+      puts object.valid?
+
+      # Hierarchical URI with authority component empty
+      object.uri = "file:///dev/null"
+      puts object.valid?
+
+      # Non-hierarchical URI
+      object.uri = "urn:ISSN:0167-6423"
+      puts object.valid?
+      """
+
+    When I run `ruby test_example_model.rb`
+
+    Then it should pass with exactly:
+      """
+      true
+      false
+      true
+      false
+      false
+      """
+
+  Scenario: IPv6 hosts need to be specified without surrounding brackets
+    Given a file named "test_example_model.rb" with:
+      """ruby
+      require "active_model"
+      require "uri_format_validator"
+
+      class ExampleModel
+        include ActiveModel::Validations
+
+        attr_accessor :uri
+        validates :uri, uri: { host: "::1" }
+      end
+
+      object = ExampleModel.new
+
+      object.uri = "https://[::1]/example/path"
+      puts object.valid?
+      """
+
+    When I run `ruby test_example_model.rb`
+
+    Then it should pass with exactly:
+      """
+      true
+      """
+
+  Scenario: A domain and the IP address it resolves to are considered to be different hosts
+    Given a file named "test_example_model.rb" with:
+      """ruby
+      require "active_model"
+      require "uri_format_validator"
+
+      class ExampleModel
+        include ActiveModel::Validations
+
+        attr_accessor :uri
+        validates :uri, uri: { host: "localhost" }
+      end
+
+      object = ExampleModel.new
+
+      object.uri = "https://localhost/example/path"
+      puts object.valid?
+
+      object.uri = "https://127.0.0.1/example/path"
+      puts object.valid?
+
+      object.uri = "https://[::1]/example/path"
+      puts object.valid?
+      """
+
+    When I run `ruby test_example_model.rb`
+
+    Then it should pass with exactly:
+      """
+      true
+      false
+      false
+      """

--- a/lib/uri_format_validator/validators/uri_validator.rb
+++ b/lib/uri_format_validator/validators/uri_validator.rb
@@ -33,7 +33,7 @@ module UriFormatValidator
         uri = string_to_uri(uri_string)
         invalid unless uri
 
-        validate_against_options(uri, :scheme, :retrievable)
+        validate_against_options(uri, :scheme, :host, :retrievable)
       end
 
       def string_to_uri(uri_string)
@@ -55,6 +55,11 @@ module UriFormatValidator
           next unless options[option_name]
           send(:"validate_#{option_name}", options[option_name], uri)
         end
+      end
+
+      def validate_host(host_or_hosts, uri)
+        hosts = Array.wrap(host_or_hosts)
+        invalid unless uri.hostname.in?(hosts)
       end
 
       def validate_scheme(scheme_or_schemes, uri)

--- a/spec/uri_validator_spec.rb
+++ b/spec/uri_validator_spec.rb
@@ -53,6 +53,89 @@ RSpec.describe UriFormatValidator::Validators::UriValidator do
     end
   end
 
+  describe ":host option" do
+    let(:http_uri) { "http://example.com/relative/path" }
+    let(:https_uri) { "https://another.example.com/different/path" }
+    let(:http_ipv6_uri) { "http://[::1]/relative/path" }
+    let(:local_file_uri) { "file:///dev/null" }
+    let(:urn) { "urn:ISSN:0167-6423" }
+
+    before do
+      Post.validates :url, uri: validation_options
+    end
+
+    context "when unspecified" do
+      let(:validation_options) { {} }
+
+      it "allows URIs with any host subcomponent" do
+        allow_uri(http_uri)
+        allow_uri(https_uri)
+        allow_uri(http_ipv6_uri)
+      end
+
+      it "allows URIs which host subcomponent is missing" do
+        allow_uri(local_file_uri)
+        allow_uri(urn)
+      end
+    end
+
+    context "when is false" do
+      let(:validation_options) { { host: false } }
+
+      it "allows URIs with any host subcomponent" do
+        allow_uri(http_uri)
+        allow_uri(https_uri)
+        allow_uri(http_ipv6_uri)
+      end
+
+      it "allows URIs which host subcomponent is missing" do
+        allow_uri(local_file_uri)
+        allow_uri(urn)
+      end
+    end
+
+    context "when is a string" do
+      let(:validation_options) { { host: "example.com" } }
+
+      it "allows URIs which host subcomponent equals to specified string" do
+        allow_uri(http_uri)
+      end
+
+      it "disallows URIs which host subcomponent is different than specified \
+          string, even if it's a subdomain of that string" do
+        disallow_uri(https_uri)
+        disallow_uri(http_ipv6_uri)
+      end
+
+      it "disallows URIs which host subcomponent is missing" do
+        disallow_uri(local_file_uri)
+        disallow_uri(urn)
+      end
+    end
+
+    context "when is an array of strings" do
+      let(:validation_options) do
+        { host: ["example.test", "example.com", "::1"] }
+      end
+
+      it "allows URIs which host subcomponent is included in the specified \
+          array" do
+        allow_uri(http_uri)
+        allow_uri(http_ipv6_uri)
+      end
+
+      it "disallows URIs which host subcomponent is not included in \
+          the specified array" do
+        disallow_uri(https_uri)
+      end
+
+      it "disallows URIs which host subcomponent is missing" do
+        disallow_uri(local_file_uri)
+        disallow_uri(urn)
+      end
+    end
+  end
+
   describe ":scheme option" do
     let(:http_uri) { "http://example.com/relative/path" }
     let(:https_uri) { "https://another.example.com/different/path" }


### PR DESCRIPTION
Allow limiting acceptable URIs to those with their hosts matching specified constraints.