### PR TITLE
Fix checks for URL retrievability

### DIFF
--- a/lib/uri_format_validator/reacher.rb
+++ b/lib/uri_format_validator/reacher.rb
@@ -16,7 +16,7 @@ module UriFormatValidator
     # Tests whether given +url+ is retrievable, that is making a HEAD request
     # results with 2xx status code.
     def retrievable?
-      head_response.is_a?(Net::HTTPSuccess)
+      http_or_https? && head_response.is_a?(Net::HTTPSuccess)
     end
 
     private
@@ -35,6 +35,10 @@ module UriFormatValidator
 
     def use_ssl?
       url.scheme == "https"
+    end
+
+    def http_or_https?
+      %w[http https].include? url.scheme
     end
   end
 end

--- a/spec/reacher_spec.rb
+++ b/spec/reacher_spec.rb
@@ -28,6 +28,10 @@ RSpec.describe UriFormatValidator::Reacher do
       stub_request(:head, url_s).to_return(status: 500)
       expect(retval_for(url_s)).to be(false)
     end
+
+    it "returns false for URL schemes other than http or https" do
+      expect(retval_for("ssh://host.example.test/resource")).to be(false)
+    end
   end
 
   def retval_for(url)

--- a/spec/uri_validator_spec.rb
+++ b/spec/uri_validator_spec.rb
@@ -220,7 +220,7 @@ RSpec.describe UriFormatValidator::Validators::UriValidator do
     let(:retrievable_http_url) { "http://example.com/relative/path" }
     let(:retrievable_https_url) { "https://example.com/relative/path" }
     let(:unretrievable_http_url) { "http://example.com/does/not/exist" }
-    let(:retrievable_ssh_url) { "ssh://git@github.com:riboseinc/some_repo.git" }
+    let(:retrievable_ssh_url) { "ssh://git@github.com/riboseinc/some_repo.git" }
 
     before do
       Post.validates :url, uri: validation_options

--- a/spec/uri_validator_spec.rb
+++ b/spec/uri_validator_spec.rb
@@ -247,7 +247,6 @@ RSpec.describe UriFormatValidator::Validators::UriValidator do
       end
 
       it "allows URI which scheme is different than http or https" do
-        pending "The list of allowed schemes is broken, see issue #62"
         allow_uri(retrievable_ssh_url)
       end
     end
@@ -268,7 +267,6 @@ RSpec.describe UriFormatValidator::Validators::UriValidator do
       end
 
       it "allows URI which scheme is different than http or https" do
-        pending "The list of allowed schemes is broken, see issue #62"
         allow_uri(retrievable_ssh_url)
       end
     end


### PR DESCRIPTION
Specs were marked as pending due to #62. However, the predefined list of allowed schemes is no longer on master, so they should be re-enabled now. They were still failing due to bug in `Reacher` class, which is fixed in this pull request.