### PR TITLE
Support different ways of writing IPv6 addresses

### DIFF
--- a/features/uri_component_constraints/host.feature
+++ b/features/uri_component_constraints/host.feature
@@ -1,4 +1,12 @@
 Feature: Host component constraints
+  URI host may be limited to certain values by passing a string, an array of
+  strings, or a regular expression in the `host` option.  Domain names, IPv4,
+  and IPv6 addresses are supported.
+
+  IPv6 addresses should be written without surrounding brackets, and may be
+  written using the shortened form (e.g. `0:0:0:0:0:0:0:1` and `::1` are
+  equivalent`).
+
   Scenario: By default, accept every valid URI
     Given a file named "test_example_model.rb" with:
       """ruby

--- a/lib/uri_format_validator.rb
+++ b/lib/uri_format_validator.rb
@@ -2,6 +2,7 @@
 #
 
 require "uri_format_validator/version"
+require "uri_format_validator/util"
 require "uri_format_validator/constraints"
 require "uri_format_validator/localization"
 require "uri_format_validator/reacher"

--- a/lib/uri_format_validator/constraints.rb
+++ b/lib/uri_format_validator/constraints.rb
@@ -41,7 +41,7 @@ module UriFormatValidator
 
     def check_host(host_or_hosts, uri)
       hosts = Array.wrap(host_or_hosts)
-      mismatch unless hosts.any? { |h| h === uri.hostname }
+      mismatch unless hosts.any? { |h| host_matches?(h, uri.hostname) }
     end
 
     def check_scheme(scheme_or_schemes, uri)
@@ -51,6 +51,17 @@ module UriFormatValidator
 
     def check_retrievable(option, uri)
       mismatch if option && !Reacher.new(uri).retrievable?
+    end
+
+    def host_matches?(expectation, candidate)
+      case expectation
+      when Regexp
+        expectation.match(candidate)
+      when String
+        Util.hosts_eql?(expectation, candidate)
+      else
+        false
+      end
     end
   end
 end

--- a/lib/uri_format_validator/util.rb
+++ b/lib/uri_format_validator/util.rb
@@ -23,5 +23,14 @@ module UriFormatValidator
 
       hostname
     end
+
+    # Compare two hosts containing host names (either domain names or IP
+    # addresses).  Contrary to IPAddr#==, works reliably in MRI < 2.4 as
+    # it does not raise exceptions.
+    def hosts_eql?(a, b)
+      parse_host(a) == parse_host(b)
+    rescue IPAddr::InvalidAddressError
+      false
+    end
   end
 end

--- a/lib/uri_format_validator/util.rb
+++ b/lib/uri_format_validator/util.rb
@@ -1,0 +1,27 @@
+require "ipaddr"
+
+module UriFormatValidator
+  module Util
+    module_function
+
+    # Attempts to convert passed string which is expected to contain a host name
+    # to a more suitable class.
+    #
+    # For blank strings, it returns +nil+. For strings which look like an IP
+    # address, it returns an instance of +IPAddr+. Otherwise, it returns
+    # the unmodified argument (domain name).
+    #
+    # IPv6 addresses are allowed to be surrounded with square brackets,
+    # as they show up in URIs.
+    def parse_host(hostname)
+      return nil if hostname.blank?
+
+      begin
+        return IPAddr.new(hostname)
+      rescue IPAddr::InvalidAddressError
+      end
+
+      hostname
+    end
+  end
+end

--- a/spec/constraints_spec.rb
+++ b/spec/constraints_spec.rb
@@ -8,7 +8,8 @@ RSpec.describe UriFormatValidator::Constraints do
 
   describe ":host option" do
     let(:http_uri) { "http://example.com/relative/path" }
-    let(:https_uri) { "https://another.example.com/different/path" }
+    let(:https_uri) { "https://example.com/different/path" }
+    let(:subdomain_uri) { "http://another.example.com/different/path" }
     let(:http_ipv6_uri) { "http://[::1]/relative/path" }
     let(:local_file_uri) { "file:///dev/null" }
     let(:urn) { "urn:ISSN:0167-6423" }
@@ -23,6 +24,7 @@ RSpec.describe UriFormatValidator::Constraints do
       it "allows URIs with any host subcomponent" do
         allow_uri(http_uri)
         allow_uri(https_uri)
+        allow_uri(subdomain_uri)
         allow_uri(http_ipv6_uri)
       end
 
@@ -38,6 +40,7 @@ RSpec.describe UriFormatValidator::Constraints do
       it "allows URIs with any host subcomponent" do
         allow_uri(http_uri)
         allow_uri(https_uri)
+        allow_uri(subdomain_uri)
         allow_uri(http_ipv6_uri)
       end
 
@@ -52,11 +55,12 @@ RSpec.describe UriFormatValidator::Constraints do
 
       it "allows URIs which host subcomponent equals to specified string" do
         allow_uri(http_uri)
+        allow_uri(https_uri)
       end
 
       it "disallows URIs which host subcomponent is different than specified \
           string, even if it's a subdomain of that string" do
-        disallow_uri(https_uri)
+        disallow_uri(subdomain_uri)
         disallow_uri(http_ipv6_uri)
       end
 
@@ -70,12 +74,13 @@ RSpec.describe UriFormatValidator::Constraints do
       let(:validation_options) { { host: /\.example\.com$/ } }
 
       it "allows URIs which host subcomponent matches the regular expression" do
-        allow_uri(https_uri)
+        allow_uri(subdomain_uri)
       end
 
       it "disallows URIs which host subcomponent does not match the regular \
           expression" do
         disallow_uri(http_uri)
+        disallow_uri(https_uri)
         disallow_uri(http_ipv6_uri)
       end
 
@@ -93,12 +98,13 @@ RSpec.describe UriFormatValidator::Constraints do
       it "allows URIs which host subcomponent matches any element of \
           the specified array" do
         allow_uri(http_uri)
+        allow_uri(https_uri)
         allow_uri(http_ipv6_uri)
       end
 
       it "disallows URIs which host subcomponent matches neither element of \
           the specified array" do
-        disallow_uri(https_uri)
+        disallow_uri(subdomain_uri)
       end
 
       it "disallows URIs which host subcomponent is missing" do

--- a/spec/constraints_spec.rb
+++ b/spec/constraints_spec.rb
@@ -68,6 +68,22 @@ RSpec.describe UriFormatValidator::Constraints do
         disallow_uri(local_file_uri)
         disallow_uri(urn)
       end
+
+      context "which represents an IPv6 address" do
+        let(:validation_options) { { host: "0000::0:1" } }
+
+        it "recognizes various ways of text representation of the address" do
+          # See RFC 4291 "IPv6 Addressing Architecture", section 2.2.
+          # https://tools.ietf.org/html/rfc4291#section-2.2
+          allow_uri("http://[0000::0:1]")
+          allow_uri("http://[0000:0000:0000:0000:0000:0000:0000:0001]")
+          allow_uri("http://[0:0:0:0:0:0:0:1]")
+          allow_uri("http://[::1]")
+          allow_uri("http://[0:0:0::0001]")
+          disallow_uri("http://[::2]")
+          disallow_uri("http://[::]")
+        end
+      end
     end
 
     context "when is a regular expression" do

--- a/spec/util_spec.rb
+++ b/spec/util_spec.rb
@@ -38,4 +38,37 @@ RSpec.describe UriFormatValidator::Util do
         to be_kind_of(String) & eq("whatever")
     end
   end
+
+  describe "#hosts_eql?" do
+    subject { described_class.method :hosts_eql? }
+
+    example { expect(subject.("::1", "::1")).to be(true) }
+    example { expect(subject.("::1", "0::1")).to be(true) }
+    example { expect(subject.("::1", "127.0.0.1")).to be(false) }
+    example { expect(subject.("::1", "example.com")).to be(false) }
+    example { expect(subject.("::1", "")).to be(false) }
+    example { expect(subject.("::1", nil)).to be(false) }
+    example { expect(subject.("127.0.0.1", "127.0.0.1")).to be(true) }
+    example { expect(subject.("127.0.0.1", "127.0.0.2")).to be(false) }
+    example { expect(subject.("127.0.0.1", "::1")).to be(false) } # yes!
+    example { expect(subject.("127.0.0.1", "example.com")).to be(false) }
+    example { expect(subject.("127.0.0.1", "")).to be(false) }
+    example { expect(subject.("127.0.0.1", nil)).to be(false) }
+    example { expect(subject.("example.com", "example.com")).to be(true) }
+    example { expect(subject.("example.com", "www.example.com")).to be(false) }
+    example { expect(subject.("example.com", "::1")).to be(false) }
+    example { expect(subject.("example.com", "127.0.0.1")).to be(false) }
+    example { expect(subject.("example.com", "")).to be(false) }
+    example { expect(subject.("example.com", nil)).to be(false) }
+    example { expect(subject.("", "")).to be(true) }
+    example { expect(subject.("", nil)).to be(true) }
+    example { expect(subject.("", "::1")).to be(false) }
+    example { expect(subject.("", "example.com")).to be(false) }
+    example { expect(subject.("", "127.0.0.1")).to be(false) }
+    example { expect(subject.(nil, nil)).to be(true) }
+    example { expect(subject.(nil, "")).to be(true) }
+    example { expect(subject.(nil, "::1")).to be(false) }
+    example { expect(subject.(nil, "example.com")).to be(false) }
+    example { expect(subject.(nil, "127.0.0.1")).to be(false) }
+  end
 end

--- a/spec/util_spec.rb
+++ b/spec/util_spec.rb
@@ -1,0 +1,41 @@
+# (c) Copyright 2017 Ribose Inc.
+#
+
+require "spec_helper"
+
+RSpec.describe UriFormatValidator::Util do
+  describe "#parse_host" do
+    subject { described_class.method :parse_host }
+
+    it "returns nil for nil or blank string" do
+      expect(subject.(nil)).to be(nil)
+      expect(subject.(" ")).to be(nil)
+    end
+
+    it "returns an IPAddr for strings which look like IPv4 addresses" do
+      expect(subject.("127.0.0.1")).
+        to be_kind_of(IPAddr) & eq("127.0.0.1")
+    end
+
+    it "returns an IPAddr for strings which look like IPv6 addresses" do
+      expect(subject.("::1")).
+        to be_kind_of(IPAddr) & eq("::1")
+      expect(subject.("[::1]")).
+        to be_kind_of(IPAddr) & eq("::1")
+      expect(subject.("1:2:3:4:5:6:7:8")).
+        to be_kind_of(IPAddr) & eq("1:2:3:4:5:6:7:8")
+      expect(subject.("[1:2:3:4:5:6:7:8]")).
+        to be_kind_of(IPAddr) & eq("1:2:3:4:5:6:7:8")
+    end
+
+    it "returns unmodified argument for non-blank strings which don't \
+        represent IP addresses" do
+      expect(subject.("localhost")).
+        to be_kind_of(String) & eq("localhost")
+      expect(subject.("www.example.test")).
+        to be_kind_of(String) & eq("www.example.test")
+      expect(subject.("whatever")).
+        to be_kind_of(String) & eq("whatever")
+    end
+  end
+end


### PR DESCRIPTION
RFC 4291 defines a shortened notation for IPv6 addresses, and that should be taken into account when comparing host names. For instance, `0:0:0:0:0:0:0:1`, and `::1` are equivalent.