### PR TITLE
Prepare for Bundler 2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,9 @@ language: ruby
 before_install:
   - gem install bundler -v 1.17.3
 
+install:
+  - bundle _1.17.3_ install --jobs=3 --retry=3 --path=${BUNDLE_PATH:-vendor/bundle}
+
 script:
   - bundle exec rspec
   - bundle exec cucumber

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ dist: trusty
 language: ruby
 
 before_install:
-  - gem install bundler -v 1.15.4
+  - gem install bundler -v 1.17.3
 
 script:
   - bundle exec rspec

--- a/uri_format_validator.gemspec
+++ b/uri_format_validator.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "addressable", "~> 2.5"
 
   spec.add_development_dependency "aruba", "~> 0.14"
-  spec.add_development_dependency "bundler", "~> 1.14"
+  spec.add_development_dependency "bundler", ">= 1.14"
   spec.add_development_dependency "cucumber", "~> 3.0"
   spec.add_development_dependency "pry"
   spec.add_development_dependency "rake", "~> 10.0"


### PR DESCRIPTION
Bundler 2 has been released recently. However, it is incompatible with Rails 4, hence we need to ensure the 1.x version in Travis CI.