### PR TITLE
Use #eval_gemfile in gemfiles

### DIFF
--- a/gemfiles/rails-4.0.gemfile
+++ b/gemfiles/rails-4.0.gemfile
@@ -1,3 +1,3 @@
-eval File.read(File.expand_path("common.gemfile", __dir__))
+eval_gemfile "common.gemfile"
 
 gem "activemodel", "~> 4.0.0"

--- a/gemfiles/rails-4.1.gemfile
+++ b/gemfiles/rails-4.1.gemfile
@@ -1,3 +1,3 @@
-eval File.read(File.expand_path("common.gemfile", __dir__))
+eval_gemfile "common.gemfile"
 
 gem "activemodel", "~> 4.1.0"

--- a/gemfiles/rails-4.2.gemfile
+++ b/gemfiles/rails-4.2.gemfile
@@ -1,3 +1,3 @@
-eval File.read(File.expand_path("common.gemfile", __dir__))
+eval_gemfile "common.gemfile"
 
 gem "activemodel", "~> 4.2.0"

--- a/gemfiles/rails-5.0.gemfile
+++ b/gemfiles/rails-5.0.gemfile
@@ -1,3 +1,3 @@
-eval File.read(File.expand_path("common.gemfile", __dir__))
+eval_gemfile "common.gemfile"
 
 gem "activemodel", "~> 5.0.0"

--- a/gemfiles/rails-5.1.gemfile
+++ b/gemfiles/rails-5.1.gemfile
@@ -1,3 +1,3 @@
-eval File.read(File.expand_path("common.gemfile", __dir__))
+eval_gemfile "common.gemfile"
 
 gem "activemodel", "~> 5.1.0"

--- a/gemfiles/rails-5.2.gemfile
+++ b/gemfiles/rails-5.2.gemfile
@@ -1,3 +1,3 @@
-eval File.read(File.expand_path("common.gemfile", __dir__))
+eval_gemfile "common.gemfile"
 
 gem "activemodel", "~> 5.2.0"

--- a/gemfiles/rails-head.gemfile
+++ b/gemfiles/rails-head.gemfile
@@ -1,3 +1,3 @@
-eval File.read(File.expand_path("common.gemfile", __dir__))
+eval_gemfile "common.gemfile"
 
 gem "activemodel", github: "rails/rails"


### PR DESCRIPTION
Replace `Kernel#eval` with `#eval_gemfile` from Bundler's DSL.